### PR TITLE
Fix can't use same config name in multiple config file.

### DIFF
--- a/src/Ciandt/Behat/PlaceholdersExtension/Config/PlaceholdersRepository.php
+++ b/src/Ciandt/Behat/PlaceholdersExtension/Config/PlaceholdersRepository.php
@@ -62,7 +62,7 @@ class PlaceholdersRepository
             $placeholder_maps[$tag]['config'] = [];
 
             foreach ($file_path as $path) {
-                $placeholder_maps[$tag]['config'] = array_merge_recursive(
+                $placeholder_maps[$tag]['config'] = array_replace_recursive(
                     $placeholder_maps[$tag]['config'],
                     Yaml::parse(file_get_contents($path))
                 );


### PR DESCRIPTION
When you are using multiple config files and there is a same variable in all config file.
I think the correct behavior is to use the variable values in the last configuration file.
But currently, the code will throw error:
`Fatal error: No homepage replacement was defined on runtime or on config/config.yml,config/config-en.yml>default>placeholders>variable1 for variant  and environment default (Behat\Testwork\Call\Exception\FatalThrowableError)`

```
    Ciandt\Behat\PlaceholdersExtension: &placeholders
      variant_tags: ~
      config_tags:
        config:
          - "%paths.base%/config/config.yml"
          - "%paths.base%/config/config-en.yml"
```
config.yml
```
default:
  placeholders:
    variable1: '/'
```
config-en.yml
```
default:
  placeholders:
    variable1: '/about'
```
```
Array
(
    [default] => Array
        (
            [placeholders] => Array
                (
                    [variable1] => Array  # it will to be a string "/about", not a array
                        (
                            [0] => /
                            [1] => /about
                        )

                )

        )

)
```